### PR TITLE
Fix KeyError that can occur in properties_get_all_dict

### DIFF
--- a/src/sdbus/dbus_proxy_async_interfaces.py
+++ b/src/sdbus/dbus_proxy_async_interfaces.py
@@ -94,8 +94,9 @@ class DbusPropertiesInterfaceAsync(
             dbus_properties_data = await self._properties_get_all(
                 interface_name)
             for member_name, variant in dbus_properties_data.items():
-                python_name = self._dbus_to_python_name_map[member_name]
-                properties[python_name] = variant[1]
+                python_name = self._dbus_to_python_name_map.get(member_name)
+                if python_name:
+                    properties[python_name] = variant[1]
 
         return properties
 

--- a/src/sdbus/dbus_proxy_sync_interfaces.py
+++ b/src/sdbus/dbus_proxy_sync_interfaces.py
@@ -68,8 +68,9 @@ class DbusPropertiesInterface(
             dbus_properties_data = self._properties_get_all(
                 interface_name)
             for member_name, variant in dbus_properties_data.items():
-                python_name = self._dbus_to_python_name_map[member_name]
-                properties[python_name] = variant[1]
+                python_name = self._dbus_to_python_name_map.get(member_name)
+                if python_name:
+                    properties[python_name] = variant[1]
 
         return properties
 


### PR DESCRIPTION
This `KeyError` occurs when an object has properties that area not defined on the interface. I encountered this error when an object whose properties I was querying had extra properties that were not present in any of the interface specifications.

This fix will ignore fields not defined in the interface.

As a side note, this `KeyError` was not surfaced to my application. In order to determine why `properties_get_all_dict` was hanging, I needed to debug the internals of `python-sdbus`. Is this the expected behavior?