### PR TITLE
Default 'DbusPropertyEmitsChangeFlag' to true.

### DIFF
--- a/src/sdbus/interface_generator.py
+++ b/src/sdbus/interface_generator.py
@@ -415,7 +415,7 @@ class DbusPropertyIntrospection(DbusMemberAbstract):
 
         self.dbus_signature = element.attrib['type']
 
-        self.emits_changed: Optional[str] = None
+        self.emits_changed: Optional[str] = 'DbusPropertyEmitsChangeFlag'
         self.is_explicit = False
 
         access_type = element.attrib['access']


### PR DESCRIPTION
When parsing a XML spec, according to the dbus spec 'DbusPropertyEmitsChangeFlag' should default
to true if not set

> The value for the annotation defaults to true if the enclosing interface element
> does not specify the annotation.
> Otherwise it defaults to the value specified in the enclosing interface element.

[spec](https://dbus.freedesktop.org/doc/dbus-specification.html#introspection-format)