### PR TITLE
Support blocking interface generation

### DIFF
--- a/src/sdbus/__main__.py
+++ b/src/sdbus/__main__.py
@@ -25,7 +25,7 @@ from typing import List
 
 from .interface_generator import (
     DbusInterfaceIntrospection,
-    generate_async_py_file,
+    generate_py_file,
     interfaces_from_file,
     interfaces_from_str,
 )
@@ -48,9 +48,11 @@ def run_gen_from_connection(namespace: Namespace) -> None:
         itrospection = connection.dbus_introspect()
         interfaces.extend(interfaces_from_str(itrospection))
 
-    print(
-        generate_async_py_file(
-            interfaces, namespace.no_imports_header))
+    print(generate_py_file(
+        interfaces,
+        namespace.no_imports_header,
+        namespace.generate_blocking,
+    ))
 
 
 def run_gen_from_file(namespace: Namespace) -> None:
@@ -59,9 +61,11 @@ def run_gen_from_file(namespace: Namespace) -> None:
     for file in namespace.filenames:
         interfaces.extend(interfaces_from_file(file))
 
-    print(
-        generate_async_py_file(
-            interfaces, namespace.no_imports_header))
+    print(generate_py_file(
+        interfaces,
+        namespace.no_imports_header,
+        namespace.generate_blocking,
+    ))
 
 
 def generator_main() -> None:
@@ -78,6 +82,10 @@ def generator_main() -> None:
     generate_from_file_parser.add_argument(
         '--no-imports-header', action='store_false', default=True,
         help="Do NOT include 'import' header",
+    )
+    generate_from_file_parser.add_argument(
+        '--generate-blocking', action='store_true', default=False,
+        help='Generate a blocking interface class. Default is async.'
     )
 
     generate_from_connection = subparsers.add_parser('gen-from-connection')
@@ -101,6 +109,10 @@ def generator_main() -> None:
     generate_from_connection.add_argument(
         '--no-imports-header', action='store_false', default=True,
         help="Do NOT include 'import' header",
+    )
+    generate_from_connection.add_argument(
+        '--generate-blocking', action='store_true', default=False,
+        help='Generate a blocking interface class. Default is async.'
     )
     generate_from_connection.add_argument(
         '--system',

--- a/test/test_interface_generator.py
+++ b/test/test_interface_generator.py
@@ -25,7 +25,7 @@ from unittest import SkipTest, TestCase, main
 from sdbus.interface_generator import (
     DbusSigToTyping,
     camel_case_to_snake_case,
-    generate_async_py_file,
+    generate_py_file,
     interface_name_to_class,
     interfaces_from_str,
 )
@@ -193,7 +193,7 @@ class TestConverter(TestCase):
                         False,
                     )
 
-        generated = generate_async_py_file(interfaces_intro)
+        generated = generate_py_file(interfaces_intro)
         self.assertIn('flags=DbusPropertyEmitsInvalidationFlag', generated)
         self.assertIn('flags=DbusPropertyConstFlag', generated)
 


### PR DESCRIPTION
Blocking API is convenient for small applications, it makes sense to provide a way to generate classes for it as well.
I added an option `--generate-blocking` to the generation commands, the default is still to generate async code.