### PR TITLE
Improve naming and move code for exporting attributes to the attribute's classes

### DIFF
--- a/src/sdbus/dbus_common_elements.py
+++ b/src/sdbus/dbus_common_elements.py
@@ -19,6 +19,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from inspect import getfullargspec
 from typing import TYPE_CHECKING, Generic, TypeVar
 
@@ -49,16 +50,21 @@ if TYPE_CHECKING:
 T = TypeVar('T')
 
 
-class DbusSomethingCommon:
+class DbusAttributeCommon(ABC):
     interface_name: str
     serving_enabled: bool
 
+    @property
+    @abstractmethod
+    def attribute_name(self) -> str:
+        ...
 
-class DbusSomethingAsync(DbusSomethingCommon):
+
+class DbusAttributeAsync(DbusAttributeCommon):
     ...
 
 
-class DbusSomethingSync(DbusSomethingCommon):
+class DbusAttributeSync(DbusAttributeCommon):
     ...
 
 
@@ -83,7 +89,7 @@ class DbusInterfaceMetaCommon(type):
                 ...
 
         for attr_name, attr in namespace.items():
-            if not isinstance(attr, DbusSomethingCommon):
+            if not isinstance(attr, DbusAttributeCommon):
                 continue
 
             # TODO: Fix async metaclass copying all methods
@@ -112,7 +118,8 @@ MEMBER_NAME_REQUIREMENTS = (
 )
 
 
-class DbusMethodCommon(DbusSomethingCommon):
+class DbusMethodCommon(DbusAttributeCommon):
+
 
     def __init__(
             self,
@@ -230,8 +237,12 @@ class DbusMethodCommon(DbusSomethingCommon):
 
         return new_args_list
 
+    @property
+    def attribute_name(self) -> str:
+        return self.method_name
 
-class DbusPropertyCommon(DbusSomethingCommon):
+
+class DbusPropertyCommon(DbusAttributeCommon):
     def __init__(self,
                  property_name: Optional[str],
                  property_signature: str,
@@ -261,8 +272,12 @@ class DbusPropertyCommon(DbusSomethingCommon):
         self.property_signature = property_signature
         self.flags = flags
 
+    @property
+    def attribute_name(self) -> str:
+        return self.property_name
 
-class DbusSignalCommon(DbusSomethingCommon):
+
+class DbusSignalCommon(DbusAttributeCommon):
     def __init__(self,
                  signal_name: Optional[str],
                  signal_signature: str,
@@ -289,6 +304,10 @@ class DbusSignalCommon(DbusSomethingCommon):
 
         self.__doc__ = original_method.__doc__
         self.__annotations__ = original_method.__annotations__
+
+    @property
+    def attribute_name(self) -> str:
+        return self.signal_name
 
 
 class DbusBindedAsync:

--- a/src/sdbus/dbus_common_elements.py
+++ b/src/sdbus/dbus_common_elements.py
@@ -45,6 +45,7 @@ if TYPE_CHECKING:
 
     SelfMeta = TypeVar('SelfMeta', bound="DbusInterfaceMetaCommon")
 
+    from .dbus_proxy_async_interface_base import DbusExportHandle
     from .sd_bus_internals import SdBus, SdBusInterface
 
 T = TypeVar('T')
@@ -310,11 +311,20 @@ class DbusSignalCommon(DbusAttributeCommon):
         return self.signal_name
 
 
-class DbusBoundAsync:
-    ...
+class DbusBoundAttribute(ABC):
+    @property
+    @abstractmethod
+    def attribute(self) -> DbusAttributeCommon:
+        ...
 
 
-class DbusBoundSync:
+class DbusLocalAttributeAsync(DbusBoundAttribute):
+    @abstractmethod
+    def append_to_interface(self, interface: SdBusInterface, handle: DbusExportHandle) -> None:
+        ...
+
+
+class DbusProxyAttributeAsync(DbusBoundAttribute):
     ...
 
 

--- a/src/sdbus/dbus_common_elements.py
+++ b/src/sdbus/dbus_common_elements.py
@@ -310,11 +310,11 @@ class DbusSignalCommon(DbusAttributeCommon):
         return self.signal_name
 
 
-class DbusBindedAsync:
+class DbusBoundAsync:
     ...
 
 
-class DbusBindedSync:
+class DbusBoundSync:
     ...
 
 

--- a/src/sdbus/dbus_proxy_async_interface_base.py
+++ b/src/sdbus/dbus_proxy_async_interface_base.py
@@ -23,7 +23,7 @@ from copy import copy
 from inspect import getmembers
 from itertools import chain
 from types import MethodType
-from typing import TYPE_CHECKING, Any, Callable, cast
+from typing import TYPE_CHECKING, Any, Callable, cast, Protocol
 from warnings import warn
 from weakref import WeakKeyDictionary, WeakValueDictionary
 
@@ -37,14 +37,11 @@ from .dbus_common_elements import (
     DbusAttributeAsync,
     DbusAttributeCommon,
     DbusAttributeSync,
+    DbusLocalAttributeAsync,
 )
 from .dbus_common_funcs import get_default_bus
-from .dbus_proxy_async_method import DbusMethodAsync, DbusLocalMethodAsync
-from .dbus_proxy_async_property import (
-    DbusPropertyAsync,
-    DbusLocalPropertyAsync,
-)
-from .dbus_proxy_async_signal import DbusSignalAsync, DbusLocalSignalAsync
+from .dbus_proxy_async_method import DbusMethodAsync
+from .dbus_proxy_async_property import DbusPropertyAsync
 from .sd_bus_internals import SdBusInterface
 
 if TYPE_CHECKING:
@@ -61,8 +58,7 @@ if TYPE_CHECKING:
         Union,
     )
 
-    from .dbus_common_elements import DbusBoundAsync
-    from .sd_bus_internals import SdBus, SdBusSlot
+    from .sd_bus_internals import SdBus
 
     T = TypeVar('T')
     Self = TypeVar('Self', bound="DbusInterfaceBaseAsync")
@@ -335,26 +331,17 @@ class DbusInterfaceBaseAsync(metaclass=DbusInterfaceMetaAsync):
         if bus is None:
             bus = get_default_bus()
 
+
         local_object_meta.attached_bus = bus
         local_object_meta.serving_object_path = object_path
         # TODO: can be optimized with a single loop
-        interface_map: Dict[str, List[DbusBoundAsync]] = {}
+        interface_map: Dict[str, List[DbusLocalAttributeAsync]] = {}
 
         for key, value in getmembers(self):
             assert not isinstance(value, DbusAttributeAsync)
 
-            if isinstance(value, DbusLocalMethodAsync):
-                interface_name = value.dbus_method.interface_name
-                if not value.dbus_method.serving_enabled:
-                    continue
-            elif isinstance(value, DbusLocalPropertyAsync):
-                interface_name = value.dbus_property.interface_name
-                if not value.dbus_property.serving_enabled:
-                    continue
-            elif isinstance(value, DbusLocalSignalAsync):
-                interface_name = value.dbus_signal.interface_name
-                if not value.dbus_signal.serving_enabled:
-                    continue
+            if isinstance(value, DbusLocalAttributeAsync) and value.attribute.serving_enabled:
+                interface_name = value.attribute.interface_name
             else:
                 continue
 
@@ -366,54 +353,20 @@ class DbusInterfaceBaseAsync(metaclass=DbusInterfaceMetaAsync):
 
             interface_member_list.append(value)
 
+        export_handle = DbusExportHandle()
+
         for interface_name, member_list in interface_map.items():
             new_interface = SdBusInterface()
             for dbus_something in member_list:
-                if isinstance(dbus_something, DbusLocalMethodAsync):
-                    new_interface.add_method(
-                        dbus_something.dbus_method.method_name,
-                        dbus_something.dbus_method.input_signature,
-                        dbus_something.dbus_method.input_args_names,
-                        dbus_something.dbus_method.result_signature,
-                        dbus_something.dbus_method.result_args_names,
-                        dbus_something.dbus_method.flags,
-                        dbus_something._dbus_reply_call,
-                    )
-                elif isinstance(dbus_something, DbusLocalPropertyAsync):
-                    getter = dbus_something._dbus_reply_get
-                    dbus_property = dbus_something.dbus_property
-
-                    if (
-                        dbus_property.property_setter is not None
-                        and
-                        dbus_property.property_setter_is_public
-                    ):
-                        setter = dbus_something._dbus_reply_set
-                    else:
-                        setter = None
-
-                    new_interface.add_property(
-                        dbus_property.property_name,
-                        dbus_property.property_signature,
-                        getter,
-                        setter,
-                        dbus_property.flags,
-                    )
-                elif isinstance(dbus_something, DbusLocalSignalAsync):
-                    new_interface.add_signal(
-                        dbus_something.dbus_signal.signal_name,
-                        dbus_something.dbus_signal.signal_signature,
-                        dbus_something.dbus_signal.args_names,
-                        dbus_something.dbus_signal.flags,
-                    )
-                else:
-                    raise TypeError
-
+                dbus_something.append_to_interface(new_interface, export_handle)
             bus.add_interface(new_interface, object_path,
                               interface_name)
             local_object_meta.activated_interfaces.append(new_interface)
 
-        return DbusExportHandle(local_object_meta)
+            assert new_interface.slot is not None
+            export_handle.append(new_interface.slot)
+
+        return export_handle
 
     def _connect(
         self,
@@ -469,13 +422,23 @@ class DbusInterfaceBaseAsync(metaclass=DbusInterfaceMetaAsync):
         return new_object
 
 
+class Closeable(Protocol):
+    def close(self) -> None:
+        ...
+
+
 class DbusExportHandle:
-    def __init__(self, local_meta: DbusLocalObjectMeta):
-        self._dbus_slots: List[SdBusSlot] = [
-            i.slot
-            for i in local_meta.activated_interfaces
-            if i.slot is not None
-        ]
+    def __init__(self, *items: Closeable) -> None:
+        self._items = list(items)
+
+    def append(self, item: Closeable) -> None:
+        self._items.append(item)
+
+    def close(self) -> None:
+        while self._items:
+            self._items.pop().close()
+
+    stop = close # for backwards compatibility
 
     async def __aenter__(self) -> DbusExportHandle:
         return self
@@ -489,7 +452,7 @@ class DbusExportHandle:
         exc_value: Any,
         traceback: Any,
     ) -> None:
-        self.stop()
+        self.close()
 
     async def __aexit__(
         self,
@@ -497,8 +460,4 @@ class DbusExportHandle:
         exc_value: Any,
         traceback: Any,
     ) -> None:
-        self.stop()
-
-    def stop(self) -> None:
-        for slot in self._dbus_slots:
-            slot.close()
+        self.close()

--- a/src/sdbus/dbus_proxy_async_interface_base.py
+++ b/src/sdbus/dbus_proxy_async_interface_base.py
@@ -39,12 +39,12 @@ from .dbus_common_elements import (
     DbusAttributeSync,
 )
 from .dbus_common_funcs import get_default_bus
-from .dbus_proxy_async_method import DbusMethodAsync, DbusMethodAsyncLocalBind
+from .dbus_proxy_async_method import DbusMethodAsync, DbusLocalMethodAsync
 from .dbus_proxy_async_property import (
     DbusPropertyAsync,
-    DbusPropertyAsyncLocalBind,
+    DbusLocalPropertyAsync,
 )
-from .dbus_proxy_async_signal import DbusSignalAsync, DbusSignalAsyncLocalBind
+from .dbus_proxy_async_signal import DbusSignalAsync, DbusLocalSignalAsync
 from .sd_bus_internals import SdBusInterface
 
 if TYPE_CHECKING:
@@ -61,7 +61,7 @@ if TYPE_CHECKING:
         Union,
     )
 
-    from .dbus_common_elements import DbusBindedAsync
+    from .dbus_common_elements import DbusBoundAsync
     from .sd_bus_internals import SdBus, SdBusSlot
 
     T = TypeVar('T')
@@ -338,20 +338,20 @@ class DbusInterfaceBaseAsync(metaclass=DbusInterfaceMetaAsync):
         local_object_meta.attached_bus = bus
         local_object_meta.serving_object_path = object_path
         # TODO: can be optimized with a single loop
-        interface_map: Dict[str, List[DbusBindedAsync]] = {}
+        interface_map: Dict[str, List[DbusBoundAsync]] = {}
 
         for key, value in getmembers(self):
             assert not isinstance(value, DbusAttributeAsync)
 
-            if isinstance(value, DbusMethodAsyncLocalBind):
+            if isinstance(value, DbusLocalMethodAsync):
                 interface_name = value.dbus_method.interface_name
                 if not value.dbus_method.serving_enabled:
                     continue
-            elif isinstance(value, DbusPropertyAsyncLocalBind):
+            elif isinstance(value, DbusLocalPropertyAsync):
                 interface_name = value.dbus_property.interface_name
                 if not value.dbus_property.serving_enabled:
                     continue
-            elif isinstance(value, DbusSignalAsyncLocalBind):
+            elif isinstance(value, DbusLocalSignalAsync):
                 interface_name = value.dbus_signal.interface_name
                 if not value.dbus_signal.serving_enabled:
                     continue
@@ -369,7 +369,7 @@ class DbusInterfaceBaseAsync(metaclass=DbusInterfaceMetaAsync):
         for interface_name, member_list in interface_map.items():
             new_interface = SdBusInterface()
             for dbus_something in member_list:
-                if isinstance(dbus_something, DbusMethodAsyncLocalBind):
+                if isinstance(dbus_something, DbusLocalMethodAsync):
                     new_interface.add_method(
                         dbus_something.dbus_method.method_name,
                         dbus_something.dbus_method.input_signature,
@@ -379,7 +379,7 @@ class DbusInterfaceBaseAsync(metaclass=DbusInterfaceMetaAsync):
                         dbus_something.dbus_method.flags,
                         dbus_something._dbus_reply_call,
                     )
-                elif isinstance(dbus_something, DbusPropertyAsyncLocalBind):
+                elif isinstance(dbus_something, DbusLocalPropertyAsync):
                     getter = dbus_something._dbus_reply_get
                     dbus_property = dbus_something.dbus_property
 
@@ -399,7 +399,7 @@ class DbusInterfaceBaseAsync(metaclass=DbusInterfaceMetaAsync):
                         setter,
                         dbus_property.flags,
                     )
-                elif isinstance(dbus_something, DbusSignalAsyncLocalBind):
+                elif isinstance(dbus_something, DbusLocalSignalAsync):
                     new_interface.add_signal(
                         dbus_something.dbus_signal.signal_name,
                         dbus_something.dbus_signal.signal_signature,

--- a/src/sdbus/dbus_proxy_async_interface_base.py
+++ b/src/sdbus/dbus_proxy_async_interface_base.py
@@ -34,9 +34,9 @@ from .dbus_common_elements import (
     DbusMethodOverride,
     DbusPropertyOverride,
     DbusRemoteObjectMeta,
-    DbusSomethingAsync,
-    DbusSomethingCommon,
-    DbusSomethingSync,
+    DbusAttributeAsync,
+    DbusAttributeCommon,
+    DbusAttributeSync,
 )
 from .dbus_common_funcs import get_default_bus
 from .dbus_proxy_async_method import DbusMethodAsync, DbusMethodAsyncLocalBind
@@ -81,7 +81,7 @@ class DbusInterfaceMetaAsync(DbusInterfaceMetaCommon):
     def _process_dbus_method_override(
         override_attr_name: str,
         override: DbusMethodOverride[T],
-        mro_dbus_elements: Dict[str, DbusSomethingAsync],
+        mro_dbus_elements: Dict[str, DbusAttributeAsync],
     ) -> DbusMethodAsync:
         try:
             original_method = mro_dbus_elements[override_attr_name]
@@ -105,7 +105,7 @@ class DbusInterfaceMetaAsync(DbusInterfaceMetaCommon):
     def _process_dbus_property_override(
         override_attr_name: str,
         override: DbusPropertyOverride[T],
-        mro_dbus_elements: Dict[str, DbusSomethingAsync],
+        mro_dbus_elements: Dict[str, DbusAttributeAsync],
     ) -> DbusPropertyAsync[Any]:
         try:
             original_property = mro_dbus_elements[override_attr_name]
@@ -137,11 +137,11 @@ class DbusInterfaceMetaAsync(DbusInterfaceMetaCommon):
         cls,
         new_class_name: str,
         namespace: Dict[str, Any],
-        mro_dbus_elements: Dict[str, DbusSomethingAsync],
+        mro_dbus_elements: Dict[str, DbusAttributeAsync],
     ) -> None:
 
         possible_collisions = namespace.keys() & mro_dbus_elements.keys()
-        new_overrides: Dict[str, DbusSomethingAsync] = {}
+        new_overrides: Dict[str, DbusAttributeAsync] = {}
 
         for attr_name, attr in namespace.items():
             if isinstance(attr, DbusMethodOverride):
@@ -173,12 +173,12 @@ class DbusInterfaceMetaAsync(DbusInterfaceMetaCommon):
     def _extract_dbus_elements(
         dbus_class: type,
         dbus_meta: DbusClassMeta,
-    ) -> Dict[str, DbusSomethingAsync]:
-        dbus_elements_map: Dict[str, DbusSomethingAsync] = {}
+    ) -> Dict[str, DbusAttributeAsync]:
+        dbus_elements_map: Dict[str, DbusAttributeAsync] = {}
 
         for attr_name in dbus_meta.python_attr_to_dbus_member.keys():
             dbus_element = dbus_class.__dict__.get(attr_name)
-            if not isinstance(dbus_element, DbusSomethingAsync):
+            if not isinstance(dbus_element, DbusAttributeAsync):
                 raise TypeError(
                     f"Expected async D-Bus element, got {dbus_element!r} "
                     f"in class {dbus_class!r}"
@@ -193,8 +193,8 @@ class DbusInterfaceMetaAsync(DbusInterfaceMetaCommon):
         cls,
         new_class_name: str,
         base_classes: Iterable[type],
-    ) -> Dict[str, DbusSomethingAsync]:
-        all_python_dbus_map: Dict[str, DbusSomethingAsync] = {}
+    ) -> Dict[str, DbusAttributeAsync]:
+        all_python_dbus_map: Dict[str, DbusAttributeAsync] = {}
         possible_collisions: Set[str] = set()
 
         for c in base_classes:
@@ -227,10 +227,10 @@ class DbusInterfaceMetaAsync(DbusInterfaceMetaCommon):
         meta: DbusClassMeta,
         interface_name: str,
     ) -> None:
-        if not isinstance(attr, DbusSomethingCommon):
+        if not isinstance(attr, DbusAttributeCommon):
             return
 
-        if isinstance(attr, DbusSomethingSync):
+        if isinstance(attr, DbusAttributeSync):
             raise TypeError(
                 "Can't mix blocking methods in "
                 f"async interface: {attr_name!r}"
@@ -239,15 +239,9 @@ class DbusInterfaceMetaAsync(DbusInterfaceMetaCommon):
         if attr.interface_name != interface_name:
             return
 
-        if isinstance(attr, DbusMethodAsync):
-            meta.dbus_member_to_python_attr[attr.method_name] = attr_name
-            meta.python_attr_to_dbus_member[attr_name] = attr.method_name
-        elif isinstance(attr, DbusPropertyAsync):
-            meta.dbus_member_to_python_attr[attr.property_name] = attr_name
-            meta.python_attr_to_dbus_member[attr_name] = attr.property_name
-        elif isinstance(attr, DbusSignalAsync):
-            meta.dbus_member_to_python_attr[attr.signal_name] = attr_name
-            meta.python_attr_to_dbus_member[attr_name] = attr.signal_name
+        if isinstance(attr, DbusAttributeAsync):
+            meta.dbus_member_to_python_attr[attr.attribute_name] = attr_name
+            meta.python_attr_to_dbus_member[attr_name] = attr.attribute_name
         else:
             raise TypeError(f"Unknown D-Bus element: {attr!r}")
 
@@ -347,7 +341,7 @@ class DbusInterfaceBaseAsync(metaclass=DbusInterfaceMetaAsync):
         interface_map: Dict[str, List[DbusBindedAsync]] = {}
 
         for key, value in getmembers(self):
-            assert not isinstance(value, DbusSomethingAsync)
+            assert not isinstance(value, DbusAttributeAsync)
 
             if isinstance(value, DbusMethodAsyncLocalBind):
                 interface_name = value.dbus_method.interface_name

--- a/src/sdbus/dbus_proxy_async_method.py
+++ b/src/sdbus/dbus_proxy_async_method.py
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING, cast, overload
 from weakref import ref as weak_ref
 
 from .dbus_common_elements import (
-    DbusBindedAsync,
+    DbusBoundAsync,
     DbusMethodCommon,
     DbusMethodOverride,
     DbusRemoteObjectMeta,
@@ -78,20 +78,20 @@ class DbusMethodAsync(DbusMethodCommon, DbusAttributeAsync):
         if obj is not None:
             dbus_meta = obj._dbus
             if isinstance(dbus_meta, DbusRemoteObjectMeta):
-                return DbusMethodAsyncProxyBind(self, dbus_meta)
+                return DbusProxyMethodAsync(self, dbus_meta)
             else:
-                return DbusMethodAsyncLocalBind(self, obj)
+                return DbusLocalMethodAsync(self, obj)
         else:
             return self
 
 
-class DbusMethodAsyncBaseBind(DbusBindedAsync):
+class DbusBoundMethodAsyncBase(DbusBoundAsync):
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
         raise NotImplementedError
 
 
-class DbusMethodAsyncProxyBind(DbusMethodAsyncBaseBind):
+class DbusProxyMethodAsync(DbusBoundMethodAsyncBase):
     def __init__(
         self,
         dbus_method: DbusMethodAsync,
@@ -145,7 +145,7 @@ class DbusMethodAsyncProxyBind(DbusMethodAsyncBaseBind):
         return self._dbus_async_call(new_call_message)
 
 
-class DbusMethodAsyncLocalBind(DbusMethodAsyncBaseBind):
+class DbusLocalMethodAsync(DbusBoundMethodAsyncBase):
     def __init__(
         self,
         dbus_method: DbusMethodAsync,

--- a/src/sdbus/dbus_proxy_async_method.py
+++ b/src/sdbus/dbus_proxy_async_method.py
@@ -30,7 +30,7 @@ from .dbus_common_elements import (
     DbusMethodCommon,
     DbusMethodOverride,
     DbusRemoteObjectMeta,
-    DbusSomethingAsync,
+    DbusAttributeAsync,
 )
 from .dbus_exceptions import DbusFailedError
 from .sd_bus_internals import DbusNoReplyFlag
@@ -52,7 +52,7 @@ def get_current_message() -> SdBusMessage:
     return CURRENT_MESSAGE.get()
 
 
-class DbusMethodAsync(DbusMethodCommon, DbusSomethingAsync):
+class DbusMethodAsync(DbusMethodCommon, DbusAttributeAsync):
 
     @overload
     def __get__(

--- a/src/sdbus/dbus_proxy_async_method.py
+++ b/src/sdbus/dbus_proxy_async_method.py
@@ -26,19 +26,21 @@ from typing import TYPE_CHECKING, cast, overload
 from weakref import ref as weak_ref
 
 from .dbus_common_elements import (
-    DbusBoundAsync,
+    DbusBoundAttribute,
     DbusMethodCommon,
     DbusMethodOverride,
+    DbusProxyAttributeAsync,
     DbusRemoteObjectMeta,
     DbusAttributeAsync,
+    DbusLocalAttributeAsync,
 )
 from .dbus_exceptions import DbusFailedError
-from .sd_bus_internals import DbusNoReplyFlag
+from .sd_bus_internals import DbusNoReplyFlag, SdBusInterface
 
 if TYPE_CHECKING:
     from typing import Any, Callable, Optional, Sequence, Type, TypeVar, Union
 
-    from .dbus_proxy_async_interface_base import DbusInterfaceBaseAsync
+    from .dbus_proxy_async_interface_base import DbusInterfaceBaseAsync, DbusExportHandle
     from .sd_bus_internals import SdBusMessage
 
     T = TypeVar('T')
@@ -85,19 +87,25 @@ class DbusMethodAsync(DbusMethodCommon, DbusAttributeAsync):
             return self
 
 
-class DbusBoundMethodAsyncBase(DbusBoundAsync):
+class DbusBoundMethodAsyncBase(DbusBoundAttribute):
+    def __init__(self, dbus_method: DbusMethodAsync) -> None:
+        self.dbus_method = dbus_method
+
+    @property
+    def attribute(self):
+        return self.dbus_method
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
         raise NotImplementedError
 
 
-class DbusProxyMethodAsync(DbusBoundMethodAsyncBase):
+class DbusProxyMethodAsync(DbusBoundMethodAsyncBase, DbusProxyAttributeAsync):
     def __init__(
         self,
         dbus_method: DbusMethodAsync,
         proxy_meta: DbusRemoteObjectMeta,
     ):
-        self.dbus_method = dbus_method
+        super().__init__(dbus_method)
         self.proxy_meta = proxy_meta
 
         self.__doc__ = dbus_method.__doc__
@@ -145,16 +153,27 @@ class DbusProxyMethodAsync(DbusBoundMethodAsyncBase):
         return self._dbus_async_call(new_call_message)
 
 
-class DbusLocalMethodAsync(DbusBoundMethodAsyncBase):
+class DbusLocalMethodAsync(DbusBoundMethodAsyncBase, DbusLocalAttributeAsync):
     def __init__(
         self,
         dbus_method: DbusMethodAsync,
         local_object: DbusInterfaceBaseAsync,
     ):
-        self.dbus_method = dbus_method
+        super().__init__(dbus_method)
         self.local_object_ref = weak_ref(local_object)
 
         self.__doc__ = dbus_method.__doc__
+
+    def append_to_interface(self, interface: SdBusInterface, handle: DbusExportHandle):
+        interface.add_method(
+            self.dbus_method.method_name,
+            self.dbus_method.input_signature,
+            self.dbus_method.input_args_names,
+            self.dbus_method.result_signature,
+            self.dbus_method.result_args_names,
+            self.dbus_method.flags,
+            self._dbus_reply_call,
+        )
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
         local_object = self.local_object_ref()
@@ -231,6 +250,10 @@ class DbusLocalMethodAsync(DbusBoundMethodAsyncBase):
 
         reply_message.send()
 
+# aliases for backwards compatibility
+DbusMethodAsyncBaseBind = DbusBoundMethodAsyncBase
+DbusMethodAsyncLocalBind = DbusLocalMethodAsync
+DbusMethodAsyncProxyBind = DbusProxyMethodAsync
 
 def dbus_method_async(
     input_signature: str = "",

--- a/src/sdbus/dbus_proxy_async_property.py
+++ b/src/sdbus/dbus_proxy_async_property.py
@@ -29,7 +29,7 @@ from .dbus_common_elements import (
     DbusPropertyCommon,
     DbusPropertyOverride,
     DbusRemoteObjectMeta,
-    DbusSomethingAsync,
+    DbusAttributeAsync,
 )
 
 if TYPE_CHECKING:
@@ -42,7 +42,7 @@ if TYPE_CHECKING:
 T = TypeVar('T')
 
 
-class DbusPropertyAsync(DbusSomethingAsync, DbusPropertyCommon, Generic[T]):
+class DbusPropertyAsync(DbusAttributeAsync, DbusPropertyCommon, Generic[T]):
     def __init__(
             self,
             property_name: Optional[str],

--- a/src/sdbus/dbus_proxy_async_property.py
+++ b/src/sdbus/dbus_proxy_async_property.py
@@ -25,18 +25,20 @@ from typing import TYPE_CHECKING, Awaitable, Generic, TypeVar, cast, overload
 from weakref import ref as weak_ref
 
 from .dbus_common_elements import (
-    DbusBoundAsync,
+    DbusBoundAttribute,
     DbusPropertyCommon,
     DbusPropertyOverride,
     DbusRemoteObjectMeta,
     DbusAttributeAsync,
+    DbusProxyAttributeAsync,
+    DbusLocalAttributeAsync,
 )
 
 if TYPE_CHECKING:
     from typing import Any, Callable, Generator, Optional, Type, Union
 
-    from .dbus_proxy_async_interface_base import DbusInterfaceBaseAsync
-    from .sd_bus_internals import SdBusMessage
+    from .dbus_proxy_async_interface_base import DbusInterfaceBaseAsync, DbusExportHandle
+    from .sd_bus_internals import SdBusMessage, SdBusInterface
 
 
 T = TypeVar('T')
@@ -126,7 +128,14 @@ class DbusPropertyAsync(DbusAttributeAsync, DbusPropertyCommon, Generic[T]):
         self.property_setter_is_public = False
 
 
-class DbusBoundPropertyAsyncBase(DbusBoundAsync, Awaitable[T]):
+class DbusBoundPropertyAsyncBase(DbusBoundAttribute, Awaitable[T]):
+    def __init__(self, dbus_property: DbusPropertyAsync[T]) -> None:
+        self.dbus_property = dbus_property
+
+    @property
+    def attribute(self):
+        return self.dbus_property
+
     def __await__(self) -> Generator[Any, None, T]:
         return self.get_async().__await__()
 
@@ -137,13 +146,13 @@ class DbusBoundPropertyAsyncBase(DbusBoundAsync, Awaitable[T]):
         raise NotImplementedError
 
 
-class DbusProxyPropertyAsync(DbusBoundPropertyAsyncBase[T]):
+class DbusProxyPropertyAsync(DbusBoundPropertyAsyncBase[T], DbusProxyAttributeAsync):
     def __init__(
         self,
         dbus_property: DbusPropertyAsync[T],
         proxy_meta: DbusRemoteObjectMeta,
     ):
-        self.dbus_property = dbus_property
+        super().__init__(dbus_property)
         self.proxy_meta = proxy_meta
 
         self.__doc__ = dbus_property.__doc__
@@ -179,16 +188,38 @@ class DbusProxyPropertyAsync(DbusBoundPropertyAsyncBase[T]):
         await bus.call_async(new_set_message)
 
 
-class DbusLocalPropertyAsync(DbusBoundPropertyAsyncBase[T]):
+class DbusLocalPropertyAsync(DbusBoundPropertyAsyncBase[T], DbusLocalAttributeAsync):
     def __init__(
         self,
         dbus_property: DbusPropertyAsync[T],
         local_object: DbusInterfaceBaseAsync,
     ):
-        self.dbus_property = dbus_property
+        super().__init__(dbus_property)
         self.local_object_ref = weak_ref(local_object)
 
         self.__doc__ = dbus_property.__doc__
+
+    def append_to_interface(self, interface: SdBusInterface, handle: DbusExportHandle):
+        getter = self._dbus_reply_get
+        dbus_property = self.dbus_property
+
+        if (
+            dbus_property.property_setter is not None
+            and
+            dbus_property.property_setter_is_public
+        ):
+
+            setter = self._dbus_reply_set
+        else:
+            setter = None
+
+        interface.add_property(
+            dbus_property.property_name,
+            dbus_property.property_signature,
+            getter,
+            setter,
+            dbus_property.flags,
+        )
 
     async def get_async(self) -> T:
         local_object = self.local_object_ref()
@@ -270,6 +301,10 @@ class DbusLocalPropertyAsync(DbusBoundPropertyAsyncBase[T]):
                 )
             )
 
+# aliases for backwards compatibility
+DbusPropertyAsyncBaseBind = DbusBoundPropertyAsyncBase
+DbusPropertyAsyncLocalBind = DbusLocalPropertyAsync
+DbusPropertyAsyncProxyBind = DbusProxyPropertyAsync
 
 def dbus_property_async(
         property_signature: str = "",

--- a/src/sdbus/dbus_proxy_async_property.py
+++ b/src/sdbus/dbus_proxy_async_property.py
@@ -25,7 +25,7 @@ from typing import TYPE_CHECKING, Awaitable, Generic, TypeVar, cast, overload
 from weakref import ref as weak_ref
 
 from .dbus_common_elements import (
-    DbusBindedAsync,
+    DbusBoundAsync,
     DbusPropertyCommon,
     DbusPropertyOverride,
     DbusRemoteObjectMeta,
@@ -84,20 +84,20 @@ class DbusPropertyAsync(DbusAttributeAsync, DbusPropertyCommon, Generic[T]):
         self,
         obj: DbusInterfaceBaseAsync,
         obj_class: Type[DbusInterfaceBaseAsync],
-    ) -> DbusPropertyAsyncBaseBind[T]:
+    ) -> DbusBoundPropertyAsyncBase[T]:
         ...
 
     def __get__(
         self,
         obj: Optional[DbusInterfaceBaseAsync],
         obj_class: Optional[Type[DbusInterfaceBaseAsync]] = None,
-    ) -> Union[DbusPropertyAsyncBaseBind[T], DbusPropertyAsync[T]]:
+    ) -> Union[DbusBoundPropertyAsyncBase[T], DbusPropertyAsync[T]]:
         if obj is not None:
             dbus_meta = obj._dbus
             if isinstance(dbus_meta, DbusRemoteObjectMeta):
-                return DbusPropertyAsyncProxyBind(self, dbus_meta)
+                return DbusProxyPropertyAsync(self, dbus_meta)
             else:
-                return DbusPropertyAsyncLocalBind(self, obj)
+                return DbusLocalPropertyAsync(self, obj)
         else:
             return self
 
@@ -126,7 +126,7 @@ class DbusPropertyAsync(DbusAttributeAsync, DbusPropertyCommon, Generic[T]):
         self.property_setter_is_public = False
 
 
-class DbusPropertyAsyncBaseBind(DbusBindedAsync, Awaitable[T]):
+class DbusBoundPropertyAsyncBase(DbusBoundAsync, Awaitable[T]):
     def __await__(self) -> Generator[Any, None, T]:
         return self.get_async().__await__()
 
@@ -137,7 +137,7 @@ class DbusPropertyAsyncBaseBind(DbusBindedAsync, Awaitable[T]):
         raise NotImplementedError
 
 
-class DbusPropertyAsyncProxyBind(DbusPropertyAsyncBaseBind[T]):
+class DbusProxyPropertyAsync(DbusBoundPropertyAsyncBase[T]):
     def __init__(
         self,
         dbus_property: DbusPropertyAsync[T],
@@ -179,7 +179,7 @@ class DbusPropertyAsyncProxyBind(DbusPropertyAsyncBaseBind[T]):
         await bus.call_async(new_set_message)
 
 
-class DbusPropertyAsyncLocalBind(DbusPropertyAsyncBaseBind[T]):
+class DbusLocalPropertyAsync(DbusBoundPropertyAsyncBase[T]):
     def __init__(
         self,
         dbus_property: DbusPropertyAsync[T],

--- a/src/sdbus/dbus_proxy_async_signal.py
+++ b/src/sdbus/dbus_proxy_async_signal.py
@@ -38,7 +38,7 @@ from .dbus_common_elements import (
     DbusLocalObjectMeta,
     DbusRemoteObjectMeta,
     DbusSignalCommon,
-    DbusSomethingAsync,
+    DbusAttributeAsync,
 )
 from .dbus_common_funcs import get_default_bus
 
@@ -52,7 +52,7 @@ if TYPE_CHECKING:
 T = TypeVar('T')
 
 
-class DbusSignalAsync(DbusSomethingAsync, DbusSignalCommon, Generic[T]):
+class DbusSignalAsync(DbusAttributeAsync, DbusSignalCommon, Generic[T]):
 
     def __init__(
         self,

--- a/src/sdbus/dbus_proxy_async_signal.py
+++ b/src/sdbus/dbus_proxy_async_signal.py
@@ -34,7 +34,7 @@ from typing import (
 from weakref import WeakSet
 
 from .dbus_common_elements import (
-    DbusBindedAsync,
+    DbusBoundAsync,
     DbusLocalObjectMeta,
     DbusRemoteObjectMeta,
     DbusSignalCommon,
@@ -85,20 +85,20 @@ class DbusSignalAsync(DbusAttributeAsync, DbusSignalCommon, Generic[T]):
         self,
         obj: DbusInterfaceBaseAsync,
         obj_class: Type[DbusInterfaceBaseAsync],
-    ) -> DbusSignalAsyncBaseBind[T]:
+    ) -> DbusBoundSignalAsyncBase[T]:
         ...
 
     def __get__(
         self,
         obj: Optional[DbusInterfaceBaseAsync],
         obj_class: Optional[Type[DbusInterfaceBaseAsync]] = None,
-    ) -> Union[DbusSignalAsyncBaseBind[T], DbusSignalAsync[T]]:
+    ) -> Union[DbusBoundSignalAsyncBase[T], DbusSignalAsync[T]]:
         if obj is not None:
             dbus_meta = obj._dbus
             if isinstance(dbus_meta, DbusRemoteObjectMeta):
-                return DbusSignalAsyncProxyBind(self, dbus_meta)
+                return DbusProxySignalAsync(self, dbus_meta)
             else:
-                return DbusSignalAsyncLocalBind(self, dbus_meta)
+                return DbusLocalSignalAsync(self, dbus_meta)
         else:
             return self
 
@@ -131,7 +131,7 @@ class DbusSignalAsync(DbusAttributeAsync, DbusSignalCommon, Generic[T]):
                 )
 
 
-class DbusSignalAsyncBaseBind(DbusBindedAsync, AsyncIterable[T], Generic[T]):
+class DbusBoundSignalAsyncBase(DbusBoundAsync, AsyncIterable[T], Generic[T]):
     async def catch(self) -> AsyncIterator[T]:
         raise NotImplementedError
         yield cast(T, None)
@@ -150,7 +150,7 @@ class DbusSignalAsyncBaseBind(DbusBindedAsync, AsyncIterable[T], Generic[T]):
         raise NotImplementedError
 
 
-class DbusSignalAsyncProxyBind(DbusSignalAsyncBaseBind[T]):
+class DbusProxySignalAsync(DbusBoundSignalAsyncBase[T]):
     def __init__(
         self,
         dbus_signal: DbusSignalAsync[T],
@@ -224,7 +224,7 @@ class DbusSignalAsyncProxyBind(DbusSignalAsyncBaseBind[T]):
         raise RuntimeError("Cannot emit signal from D-Bus proxy.")
 
 
-class DbusSignalAsyncLocalBind(DbusSignalAsyncBaseBind[T]):
+class DbusLocalSignalAsync(DbusBoundSignalAsyncBase[T]):
     def __init__(
         self,
         dbus_signal: DbusSignalAsync[T],

--- a/src/sdbus/dbus_proxy_async_signal.py
+++ b/src/sdbus/dbus_proxy_async_signal.py
@@ -34,8 +34,10 @@ from typing import (
 from weakref import WeakSet
 
 from .dbus_common_elements import (
-    DbusBoundAsync,
+    DbusBoundAttribute,
+    DbusLocalAttributeAsync,
     DbusLocalObjectMeta,
+    DbusProxyAttributeAsync,
     DbusRemoteObjectMeta,
     DbusSignalCommon,
     DbusAttributeAsync,
@@ -45,8 +47,8 @@ from .dbus_common_funcs import get_default_bus
 if TYPE_CHECKING:
     from typing import Any, Callable, Optional, Sequence, Tuple, Type, Union
 
-    from .dbus_proxy_async_interface_base import DbusInterfaceBaseAsync
-    from .sd_bus_internals import SdBus, SdBusMessage, SdBusSlot
+    from .dbus_proxy_async_interface_base import DbusInterfaceBaseAsync, DbusExportHandle
+    from .sd_bus_internals import SdBus, SdBusMessage, SdBusSlot, SdBusInterface
 
 
 T = TypeVar('T')
@@ -131,7 +133,14 @@ class DbusSignalAsync(DbusAttributeAsync, DbusSignalCommon, Generic[T]):
                 )
 
 
-class DbusBoundSignalAsyncBase(DbusBoundAsync, AsyncIterable[T], Generic[T]):
+class DbusBoundSignalAsyncBase(DbusBoundAttribute, AsyncIterable[T], Generic[T]):
+    def __init__(self, dbus_signal: DbusSignalAsync[T]) -> None:
+        self.dbus_signal = dbus_signal
+
+    @property
+    def attribute(self):
+        return self.dbus_signal
+
     async def catch(self) -> AsyncIterator[T]:
         raise NotImplementedError
         yield cast(T, None)
@@ -150,13 +159,13 @@ class DbusBoundSignalAsyncBase(DbusBoundAsync, AsyncIterable[T], Generic[T]):
         raise NotImplementedError
 
 
-class DbusProxySignalAsync(DbusBoundSignalAsyncBase[T]):
+class DbusProxySignalAsync(DbusBoundSignalAsyncBase[T], DbusProxyAttributeAsync):
     def __init__(
         self,
         dbus_signal: DbusSignalAsync[T],
         proxy_meta: DbusRemoteObjectMeta,
     ):
-        self.dbus_signal = dbus_signal
+        super().__init__(dbus_signal)
         self.proxy_meta = proxy_meta
 
         self.__doc__ = dbus_signal.__doc__
@@ -224,16 +233,24 @@ class DbusProxySignalAsync(DbusBoundSignalAsyncBase[T]):
         raise RuntimeError("Cannot emit signal from D-Bus proxy.")
 
 
-class DbusLocalSignalAsync(DbusBoundSignalAsyncBase[T]):
+class DbusLocalSignalAsync(DbusBoundSignalAsyncBase[T], DbusLocalAttributeAsync):
     def __init__(
         self,
         dbus_signal: DbusSignalAsync[T],
         local_meta: DbusLocalObjectMeta,
     ):
-        self.dbus_signal = dbus_signal
+        super().__init__(dbus_signal)
         self.local_meta = local_meta
 
         self.__doc__ = dbus_signal.__doc__
+
+    def append_to_interface(self, interface: SdBusInterface, handle: DbusExportHandle):
+        interface.add_signal(
+            self.dbus_signal.signal_name,
+            self.dbus_signal.signal_signature,
+            self.dbus_signal.args_names,
+            self.dbus_signal.flags,
+        )
 
     async def catch(self) -> AsyncIterator[T]:
         new_queue: Queue[T] = Queue()

--- a/src/sdbus/dbus_proxy_sync_interface_base.py
+++ b/src/sdbus/dbus_proxy_sync_interface_base.py
@@ -27,8 +27,8 @@ from .dbus_common_elements import (
     DbusClassMeta,
     DbusInterfaceMetaCommon,
     DbusRemoteObjectMeta,
-    DbusSomethingAsync,
-    DbusSomethingCommon,
+    DbusAttributeAsync,
+    DbusAttributeCommon,
 )
 from .dbus_proxy_sync_method import DbusMethodSync
 from .dbus_proxy_sync_property import DbusPropertySync
@@ -109,10 +109,10 @@ class DbusInterfaceMetaSync(DbusInterfaceMetaCommon):
         attr: Any,
         meta: DbusClassMeta,
     ) -> None:
-        if not isinstance(attr, DbusSomethingCommon):
+        if not isinstance(attr, DbusAttributeCommon):
             return
 
-        if isinstance(attr, DbusSomethingAsync):
+        if isinstance(attr, DbusAttributeAsync):
             raise TypeError(
                 f"Can't mix async methods in sync interface: {attr_name!r}"
             )

--- a/src/sdbus/dbus_proxy_sync_method.py
+++ b/src/sdbus/dbus_proxy_sync_method.py
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING, TypeVar, cast
 from .dbus_common_elements import (
     DbusBindedSync,
     DbusMethodCommon,
-    DbusSomethingSync,
+    DbusAttributeSync,
 )
 
 if TYPE_CHECKING:
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
 T = TypeVar('T')
 
 
-class DbusMethodSync(DbusMethodCommon, DbusSomethingSync):
+class DbusMethodSync(DbusMethodCommon, DbusAttributeSync):
     def __get__(self,
                 obj: DbusInterfaceBase,
                 obj_class: Optional[Type[DbusInterfaceBase]] = None,

--- a/src/sdbus/dbus_proxy_sync_method.py
+++ b/src/sdbus/dbus_proxy_sync_method.py
@@ -24,7 +24,7 @@ from types import FunctionType
 from typing import TYPE_CHECKING, TypeVar, cast
 
 from .dbus_common_elements import (
-    DbusBoundSync,
+    DbusBoundAttribute,
     DbusMethodCommon,
     DbusAttributeSync,
 )
@@ -45,7 +45,7 @@ class DbusMethodSync(DbusMethodCommon, DbusAttributeSync):
         return DbusLocalMethodSync(self, obj)
 
 
-class DbusLocalMethodSync(DbusBoundSync):
+class DbusLocalMethodSync(DbusBoundAttribute):
     def __init__(self,
                  dbus_method: DbusMethodSync,
                  interface: DbusInterfaceBase):
@@ -53,6 +53,10 @@ class DbusLocalMethodSync(DbusBoundSync):
         self.interface = interface
 
         self.__doc__ = dbus_method.__doc__
+
+    @property
+    def attribute(self):
+        return self.dbus_method
 
     def _call_dbus_sync(self, *args: Any) -> Any:
         new_call_message = (

--- a/src/sdbus/dbus_proxy_sync_method.py
+++ b/src/sdbus/dbus_proxy_sync_method.py
@@ -24,7 +24,7 @@ from types import FunctionType
 from typing import TYPE_CHECKING, TypeVar, cast
 
 from .dbus_common_elements import (
-    DbusBindedSync,
+    DbusBoundSync,
     DbusMethodCommon,
     DbusAttributeSync,
 )
@@ -42,10 +42,10 @@ class DbusMethodSync(DbusMethodCommon, DbusAttributeSync):
                 obj: DbusInterfaceBase,
                 obj_class: Optional[Type[DbusInterfaceBase]] = None,
                 ) -> Callable[..., Any]:
-        return DbusMethodSyncBinded(self, obj)
+        return DbusLocalMethodSync(self, obj)
 
 
-class DbusMethodSyncBinded(DbusBindedSync):
+class DbusLocalMethodSync(DbusBoundSync):
     def __init__(self,
                  dbus_method: DbusMethodSync,
                  interface: DbusInterfaceBase):

--- a/src/sdbus/dbus_proxy_sync_property.py
+++ b/src/sdbus/dbus_proxy_sync_property.py
@@ -23,7 +23,7 @@ from inspect import iscoroutinefunction
 from types import FunctionType
 from typing import TYPE_CHECKING, Generic, TypeVar, cast
 
-from .dbus_common_elements import DbusPropertyCommon, DbusSomethingSync
+from .dbus_common_elements import DbusPropertyCommon, DbusAttributeSync
 from .dbus_common_funcs import _check_sync_in_async_env
 
 if TYPE_CHECKING:
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
 T = TypeVar('T')
 
 
-class DbusPropertySync(DbusPropertyCommon, DbusSomethingSync, Generic[T]):
+class DbusPropertySync(DbusPropertyCommon, DbusAttributeSync, Generic[T]):
     def __init__(
             self,
             property_name: Optional[str],

--- a/src/sdbus/unittest.py
+++ b/src/sdbus/unittest.py
@@ -34,8 +34,8 @@ from weakref import ref as weak_ref
 
 from .dbus_common_funcs import set_default_bus
 from .dbus_proxy_async_signal import (
-    DbusSignalAsyncLocalBind,
-    DbusSignalAsyncProxyBind,
+    DbusLocalSignalAsync,
+    DbusProxySignalAsync,
 )
 from .sd_bus_internals import SdBusMessage, sd_bus_open_user
 
@@ -52,7 +52,7 @@ if TYPE_CHECKING:
 
     from .dbus_proxy_async_signal import (
         DbusSignalAsync,
-        DbusSignalAsyncBaseBind,
+        DbusBoundSignalAsyncBase,
     )
     from .sd_bus_internals import SdBus, SdBusSlot
 
@@ -124,7 +124,7 @@ class DbusSignalRecorderRemote(DbusSignalRecorderBase):
         self,
         timeout: Union[int, float],
         bus: SdBus,
-        remote_signal: DbusSignalAsyncProxyBind[Any],
+        remote_signal: DbusProxySignalAsync[Any],
     ):
         super().__init__(timeout)
         self._bus = bus
@@ -156,7 +156,7 @@ class DbusSignalRecorderLocal(DbusSignalRecorderBase):
     def __init__(
         self,
         timeout: Union[int, float],
-        local_signal: DbusSignalAsyncLocalBind[Any],
+        local_signal: DbusLocalSignalAsync[Any],
     ):
         super().__init__(timeout)
         self._local_signal_ref: weak_ref[DbusSignalAsync[Any]] = (
@@ -240,13 +240,13 @@ class IsolatedDbusTestCase(IsolatedAsyncioTestCase):
 
     def assertDbusSignalEmits(
         self,
-        signal: DbusSignalAsyncBaseBind[Any],
+        signal: DbusBoundSignalAsyncBase[Any],
         timeout: Union[int, float] = 1,
     ) -> AsyncContextManager[DbusSignalRecorderBase]:
 
-        if isinstance(signal, DbusSignalAsyncLocalBind):
+        if isinstance(signal, DbusLocalSignalAsync):
             return DbusSignalRecorderLocal(timeout, signal)
-        elif isinstance(signal, DbusSignalAsyncProxyBind):
+        elif isinstance(signal, DbusProxySignalAsync):
             return DbusSignalRecorderRemote(timeout, self.bus, signal)
         else:
             raise TypeError("Unknown or unsupported signal class.")


### PR DESCRIPTION
Hello, 

this PR makes some relatively small improvements (in my opinion) to the internal structure of the code. 

1. It renames all the *DbusSomething* classes to *DbusAttribute*.
   - "Something" referred to method/signal/property of an interface. Looking at sdbus and elsewhere, those are usually called "attributes" of the interface. Together with the other changes in this PR, I believe it makes the code clearer.
2. It renames the classes for bound attributes
   - Discussed here already https://github.com/python-sdbus/python-sdbus/issues/65
   - I believe calling the attributes "bound" is correct, the same way we have "bound methods" in Python. Thus the base classes for bound attributes is "DbusBound".
   - The concrete subclasses representing bound attributes are then called *DbusLocalMethodAsync*, *DbusLocalMethodAsync*, etc (as suggested by @igo95862 ; not repeating the "Bound" word, as it doesn't seem to be necessary in that context)
3. Most importantly, it moves some attribute-specific code from *DbusInterfaceBaseAsync* to the *DbusLocalMethodAsync*.
   - This change is my main motivation behind this PR. By having the logic of "exporting an attribute to dbus" in the attribute class itself, it gets much easier for clients of this library to extend the library with more advanced attributes (which is my case – I need to be able to implement custom versions of `@dbus_property_async` and this change makes it much easier to do so).
   - At the same time, it tries to make the code actually simpler (also slightly improving DbusExportHandle).
