### PR TITLE
Fix InterfacesRemoved signal emitted when export handle is stopped

### DIFF
--- a/src/sdbus/dbus_proxy_async_object_manager.py
+++ b/src/sdbus/dbus_proxy_async_object_manager.py
@@ -49,8 +49,8 @@ class DbusObjectManagerExportHandle(DbusExportHandle):
         self.remove_object_call = remove_object_call
 
     def stop(self) -> None:
-        super().stop()
         self.remove_object_call()
+        super().stop()
 
 
 class DbusObjectManagerInterfaceAsync(

--- a/test/test_object_manager.py
+++ b/test/test_object_manager.py
@@ -399,7 +399,10 @@ class TestObjectManager(IsolatedDbusTestCase):
             )
 
         self.assertEqual(added.output[0][0], MANAGED_PATH)
-        self.assertEqual(removed.output[0][0], MANAGED_PATH)
+
+        removed_path, removed_interfaces = removed.output[0]
+        self.assertEqual(removed_path, MANAGED_PATH)
+        self.assertIn(MANAGED_INTERFACE_NAME, removed_interfaces)
 
         with self.assertRaises(DbusUnknownObjectError):
             await managed_proxy.test_int


### PR DESCRIPTION
This PR fixes the issue reported in https://github.com/python-sdbus/python-sdbus/issues/94#issuecomment-2789669611