### PR TITLE
Iterate interfaces in the MRO reversed order

### DIFF
--- a/src/sdbus/dbus_proxy_async_interface_base.py
+++ b/src/sdbus/dbus_proxy_async_interface_base.py
@@ -295,7 +295,7 @@ class DbusInterfaceBaseAsync(metaclass=DbusInterfaceMetaAsync):
         cls,
     ) -> Iterator[tuple[str, DbusClassMeta]]:
 
-        for base in cls.__mro__:
+        for base in reversed(cls.__mro__):
             meta = DBUS_CLASS_TO_META.get(base)
             if meta is None:
                 continue

--- a/src/sdbus/dbus_proxy_async_interfaces.py
+++ b/src/sdbus/dbus_proxy_async_interfaces.py
@@ -105,6 +105,7 @@ class DbusPropertiesInterfaceAsync(
 
 
 class DbusInterfaceCommonAsync(
-        DbusPeerInterfaceAsync, DbusPropertiesInterfaceAsync,
-        DbusIntrospectableAsync):
+        DbusPropertiesInterfaceAsync,
+        DbusIntrospectableAsync,
+        DbusPeerInterfaceAsync):
     ...

--- a/src/sdbus/dbus_proxy_sync_interface_base.py
+++ b/src/sdbus/dbus_proxy_sync_interface_base.py
@@ -171,7 +171,7 @@ class DbusInterfaceBase(metaclass=DbusInterfaceMetaSync):
         cls,
     ) -> Iterator[tuple[str, DbusClassMeta]]:
 
-        for base in cls.__mro__:
+        for base in reversed(cls.__mro__):
             meta = DBUS_CLASS_TO_META.get(base)
             if meta is None:
                 continue

--- a/src/sdbus/dbus_proxy_sync_interfaces.py
+++ b/src/sdbus/dbus_proxy_sync_interfaces.py
@@ -94,9 +94,9 @@ class DbusPropertiesInterface(
 
 
 class DbusInterfaceCommon(
-        DbusPeerInterface,
+        DbusPropertiesInterface,
         DbusIntrospectable,
-        DbusPropertiesInterface):
+        DbusPeerInterface):
     ...
 
 

--- a/test/test_sdbus_async.py
+++ b/test/test_sdbus_async.py
@@ -948,8 +948,22 @@ class TestProxy(IsolatedDbusTestCase):
             async def two(self) -> int:
                 return 2
 
-        class CombinedInterface(OneInterface, TwoInterface):
+        class CombinedInterface(TwoInterface, OneInterface):
             ...
+
+        test_combined = CombinedInterface()
+        test_combined_interfaces = [
+            iface for iface, _ in test_combined._dbus_iter_interfaces_meta()
+        ]
+
+        # Verify the order of reported interfaces on the combined class.
+        self.assertEqual(test_combined_interfaces, [
+            "org.freedesktop.DBus.Peer",
+            "org.freedesktop.DBus.Introspectable",
+            "org.freedesktop.DBus.Properties",
+            "org.example.one",
+            "org.example.two",
+        ])
 
     async def test_extremely_large_string(self) -> None:
         test_object, test_object_connection = initialize_object()

--- a/test/test_sdbus_block.py
+++ b/test/test_sdbus_block.py
@@ -92,8 +92,22 @@ class TestSync(IsolatedDbusTestCase):
             def two(self) -> int:
                 raise NotImplementedError
 
-        class CombinedInterface(OneInterface, TwoInterface):
+        class CombinedInterface(TwoInterface, OneInterface):
             ...
+
+        test_combined = CombinedInterface("org.test", "/")
+        test_combined_interfaces = [
+            iface for iface, _ in test_combined._dbus_iter_interfaces_meta()
+        ]
+
+        # Verify the order of reported interfaces on the combined class.
+        self.assertEqual(test_combined_interfaces, [
+            "org.freedesktop.DBus.Peer",
+            "org.freedesktop.DBus.Introspectable",
+            "org.freedesktop.DBus.Properties",
+            "org.example.one",
+            "org.example.two",
+        ])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Iterating the MRO in the reversed order will allow to add interfaces to the given object in a well-defined way - always starting from the base class. Such ordering will be compatible with adding interfaces manually one by one.