### PR TITLE
Fix generated code for signals

### DIFF
--- a/src/sdbus/interface_generator.py
+++ b/src/sdbus/interface_generator.py
@@ -722,7 +722,7 @@ def {{ a_property.python_name }}(self) -> {{ a_property.typing }}:
     flags={{ signal.flags_str }},
 {% endif %}
 {% if signal.wants_rename %}
-    signal_name=signal.method_name,
+    signal_name="{{signal.method_name}}",
 {% endif %}
 )
 def {{ signal.python_name }}(self) -> {{ signal.typing }}:


### PR DESCRIPTION
When calling `python -m sdbus gen-from-file <introspection file>`, the generated code would generate signal decorators with the argument `signal_name=signal.method_name`. 

This PR fixes that and the argument is now `signal_name="<method_name>"`

Before:
```python
@dbus_signal_async(
        signal_signature="si",
        signal_args_names=('cellularNetworkType', 'cellularNetworkStrength'),
        signal_name=signal.method_name, # Incorrect
    )
    def refreshed(self) -> tuple[str, int]:
        raise NotImplementedError
```

After:
```python
@dbus_signal_async(
        signal_signature="si",
        signal_args_names=('cellularNetworkType', 'cellularNetworkStrength'),
        signal_name="refreshed",
    )
    def refreshed(self) -> tuple[str, int]:
        raise NotImplementedError
```